### PR TITLE
Animate background gradients with breathing and vertical drift

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -116,12 +116,47 @@ body {
   font-size: 1.0625rem;
   color: var(--text);
   line-height: 1.65;
-  background:
-    radial-gradient(ellipse 50% 50% at top left, var(--page-accent-faint), transparent),
-    radial-gradient(ellipse 50% 50% at bottom right, var(--page-accent-faint), transparent),
-    var(--bg);
+  background: var(--bg);
   min-height: 100vh;
   transition: background 0.25s ease, color 0.25s ease;
+  position: relative;
+}
+
+/* Breathing background gradients on opposing corners */
+body::before,
+body::after {
+  content: "";
+  position: fixed;
+  width: 80vw;
+  height: 80vh;
+  pointer-events: none;
+  z-index: -1;
+  will-change: opacity, transform;
+}
+
+body::before {
+  top: -20vh;
+  left: -20vw;
+  background: radial-gradient(ellipse at center, var(--page-accent-faint), transparent 60%);
+  animation: breathe-a 14s cubic-bezier(0.45, 0, 0.55, 1) infinite;
+}
+
+body::after {
+  bottom: -20vh;
+  right: -20vw;
+  background: radial-gradient(ellipse at center, var(--page-accent-faint), transparent 60%);
+  animation: breathe-b 18s cubic-bezier(0.45, 0, 0.55, 1) infinite;
+  animation-delay: -6s;
+}
+
+@keyframes breathe-a {
+  0%, 100% { opacity: 0.85; transform: scale(1); }
+  50%      { opacity: 1;    transform: scale(1.08); }
+}
+
+@keyframes breathe-b {
+  0%, 100% { opacity: 1;    transform: scale(1.06); }
+  50%      { opacity: 0.8;  transform: scale(1); }
 }
 
 [data-theme="dark"] { color-scheme: dark; }

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -138,25 +138,25 @@ body::before {
   top: -20vh;
   left: -20vw;
   background: radial-gradient(ellipse at center, var(--page-accent-faint), transparent 60%);
-  animation: breathe-a 14s cubic-bezier(0.45, 0, 0.55, 1) infinite;
+  animation: drift-a 48s cubic-bezier(0.45, 0, 0.55, 1) infinite;
 }
 
 body::after {
   bottom: -20vh;
   right: -20vw;
   background: radial-gradient(ellipse at center, var(--page-accent-faint), transparent 60%);
-  animation: breathe-b 18s cubic-bezier(0.45, 0, 0.55, 1) infinite;
-  animation-delay: -6s;
+  animation: drift-b 60s cubic-bezier(0.45, 0, 0.55, 1) infinite;
+  animation-delay: -22s;
 }
 
-@keyframes breathe-a {
-  0%, 100% { opacity: 0.85; transform: scale(1); }
-  50%      { opacity: 1;    transform: scale(1.08); }
+@keyframes drift-a {
+  0%, 100% { opacity: 0.8; transform: translateY(0)    scale(1); }
+  50%      { opacity: 1;   transform: translateY(40vh) scale(1.1); }
 }
 
-@keyframes breathe-b {
-  0%, 100% { opacity: 1;    transform: scale(1.06); }
-  50%      { opacity: 0.8;  transform: scale(1); }
+@keyframes drift-b {
+  0%, 100% { opacity: 1;   transform: translateY(0)     scale(1.06); }
+  50%      { opacity: 0.8; transform: translateY(-40vh) scale(1); }
 }
 
 [data-theme="dark"] { color-scheme: dark; }


### PR DESCRIPTION
## Summary
- Moves the corner radial gradients from the body background onto fixed `::before`/`::after` pseudo-elements so they stay in the viewport through scroll and can be animated independently
- Adds a slow breathing animation (opacity + scale) to each gradient
- Adds a long vertical drift (~40vh travel) on 48s and 60s offset cycles, so the gradient positions visibly shift over the time it takes to read a post

## Test plan
- [ ] Load a post and confirm both corner gradients are visible
- [ ] Watch for a minute — gradients should gently pulse in intensity and slowly drift vertically, never syncing up
- [ ] Scroll through a long post — gradients stay anchored to the viewport corners
- [ ] Toggle dark mode — animation continues smoothly
- [ ] Verify `prefers-reduced-motion` halts the animation (existing `@media` rule should catch it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)